### PR TITLE
Lib arrange

### DIFF
--- a/contents/how_to_use.typ
+++ b/contents/how_to_use.typ
@@ -16,8 +16,6 @@ Typstでは、PNG・JPEG・GIF・SVG フォーマットの画像をサポート�
   image("img/example.svg", width: 90%),
   placement: none, // top, bottom, auto, none
   caption: "Example of a figure.",
-  supplement: "Fig.",
-  kind: "image",
 ) <fig:fig_example>
 
 === このテンプレートにおける図の記述方法 <how_to_describe_figure_in_this_format>
@@ -31,8 +29,6 @@ Typstの文法とこのテンプレートに沿って、図を記述する方法
   placement: none, // top, bottom, auto, none
   image("img/example.svg", width: 90%),
   caption: [Example of a figure.],
-  supplement: "Fig.", // 図番号の前につける文字列(固定)
-  kind: "image", // 図目次作成のためのキーワード(固定)
 ) <fig:fig_example> // 図の参照用のラベル
 ```
 
@@ -72,8 +68,6 @@ Typstの文法とこのテンプレートに沿って、図を記述する方法
     [Right], [...], [100 mm], [191.5 mm],
     [Bottom], [...], [275 mm], [275 mm],
   ),
-  supplement: "Table",
-  kind: "table",
 ) <tab:table_example>
 
 
@@ -102,8 +96,6 @@ Typstの文法とこのテンプレートに沿って、表を記述する方法
     [Right], [...], [100 mm], [191.5 mm],
     [Bottom], [...], [275 mm], [275 mm],
   ),
-  supplement: "Table", // 表番号の前につける文字列(固定)
-  kind: "table", // 表目次作成のためのキーワード(固定)
 ) <tab:table_example> // 表の参照用のラベル
 ```
 

--- a/lib/grad_thesis_lib.typ
+++ b/lib/grad_thesis_lib.typ
@@ -372,6 +372,10 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
   show math.equation: set math.equation(supplement: [Eq.], numbering: equation_num)
 
+  show figure.caption: it => {
+    align(box(align(it, left)), center)
+  }
+
   // Display block code in a larger block with more padding.
   show raw.where(block: true): block.with(
     fill: luma(240),

--- a/lib/grad_thesis_lib.typ
+++ b/lib/grad_thesis_lib.typ
@@ -101,10 +101,10 @@
   set text(size: text_main)
   set par(leading: 1.24em, first-line-indent: 0pt)
   context{
-    let elements = query(figure.where(outlined: true, kind: "image"))
+    let elements = query(figure.where(outlined: true, kind: image))
     for el in elements {
       let chapt = counter(heading).at(el.location()).at(0)
-      let num = counter(el.kind + "-chapter" + str(chapt)).at(el.location()).at(0) + 1
+      let num = counter("image-chapter" + str(chapt)).at(el.location()).at(0) + 1
       let page_num = counter(page).at(el.location()).first()
       let caption_body = to-string(el.caption.body)
       "Fig. "
@@ -143,10 +143,10 @@
   set text(size: text_main)
   set par(leading: 1.24em, first-line-indent: 0pt)
    context{
-    let elements = query(figure.where(outlined: true, kind: "table"))
+    let elements = query(figure.where(outlined: true, kind: table))
     for el in elements {
       let chapt = counter(heading).at(el.location()).at(0)
-      let num = counter(el.kind + "-chapter" + str(chapt)).at(el.location()).at(0) + 1
+      let num = counter("table-chapter" + str(chapt)).at(el.location()).at(0) + 1
       let page_num = counter(page).at(el.location()).first()
       let caption_body = to-string(el.caption.body)
       "Table "
@@ -366,11 +366,11 @@
     ]
   }
   
-  show figure.where(kind: "table"): set figure(supplement: [Table ], numbering: table_num)
-  show figure.where(kind: "table"): set figure.caption(position: top, separator: [ ])
-  show figure.where(kind: "image"): set figure(supplement: [Fig.], numbering: img_num)
-  show figure.where(kind: "image"): set figure.caption(position: bottom, separator: [ ])
-  show math.equation: set math.equation(supplement: [式], numbering: equation_num)
+  show figure.where(kind: table): set figure(supplement: [Table], numbering: table_num)
+  show figure.where(kind: table): set figure.caption(position: top, separator: [ ])
+  show figure.where(kind: image): set figure(supplement: [Fig.], numbering: img_num)
+  show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
+  show math.equation: set math.equation(supplement: [Eq.], numbering: equation_num)
 
   // Display block code in a larger block with more padding.
   show raw.where(block: true): block.with(


### PR DESCRIPTION
This pull request includes several changes to improve the handling of figures and tables in the `Typst` template files. The most important changes involve removing unnecessary attributes from figure and table definitions, and updating the query logic in the `lib/grad_thesis_lib.typ` file.

Improvements to figure and table definitions:

* [`contents/how_to_use.typ`](diffhunk://#diff-1ea6b0ec1176c1f4debf189ca10d32d5d7994fac3ade9e0e6a45c518cc491bd6L19-L20): Removed the `supplement` and `kind` attributes from figure and table definitions to simplify the syntax. [[1]](diffhunk://#diff-1ea6b0ec1176c1f4debf189ca10d32d5d7994fac3ade9e0e6a45c518cc491bd6L19-L20) [[2]](diffhunk://#diff-1ea6b0ec1176c1f4debf189ca10d32d5d7994fac3ade9e0e6a45c518cc491bd6L34-L35) [[3]](diffhunk://#diff-1ea6b0ec1176c1f4debf189ca10d32d5d7994fac3ade9e0e6a45c518cc491bd6L75-L76) [[4]](diffhunk://#diff-1ea6b0ec1176c1f4debf189ca10d32d5d7994fac3ade9e0e6a45c518cc491bd6L105-L106)

Updates to query logic:

* [`lib/grad_thesis_lib.typ`](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eL104-R107): Updated the `query` function to use unquoted identifiers for `kind` attributes, and adjusted the logic for numbering figures and tables accordingly. [[1]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eL104-R107) [[2]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eL146-R149)
* [`lib/grad_thesis_lib.typ`](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eL369-R377): Modified the display settings for figures and equations to use the updated `kind` attributes and added alignment for figure captions.