### PR TITLE
bib_jasnaoe_format

### DIFF
--- a/lib/jasnaoe-reference.csl
+++ b/lib/jasnaoe-reference.csl
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/#) -->
+  <info>
+    <title>jasnaoe conference</title>
+    <id>http://www.zotero.org/styles/jasnaoe-conference</id>
+    <link href="http://www.zotero.org/styles/jasnaoe-conference" rel="self"/>
+    <link href="https://www.jasnaoe.or.jp/lecture/dl_lec/JASNAOE-ProcENG.20240809.pdf" rel="documentation"/>
+    <author>
+      <name>Yasuo Ichinose</name>
+      <uri>https://researchmap.jp/ichinose_y?lang=en</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="science"/>
+    <category field="generic-base"/>
+    <summary>JASNAOE conference paper format</summary>
+    <updated>2024-09-15T05:47:04+00:00</updated>
+    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if type="chapter" match="any"/>
+      <else>
+        <text variable="title" suffix=","/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author" delimiter="," suffix=": ">
+      <name and="text" delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short"/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="volume" type="article" match="any"/>
+      <else-if variable="DOI">
+        <text variable="DOI" prefix="doi:" suffix=","/>
+      </else-if>
+      <else-if variable="URL">
+        <text term="at"/>
+        <text variable="URL" prefix=" "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issuance">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song chapter paper-conference" match="any">
+        <group delimiter=", " suffix=".">
+          <text variable="publisher" form="long"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if type="article">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre" match="any">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+            <else>
+              <text term="article" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text term="at"/>
+          <choose>
+            <if variable="DOI" match="any">
+              <text variable="DOI" prefix="https://doi.org/"/>
+            </if>
+            <else>
+              <text variable="URL"/>
+            </else>
+          </choose>
+          <date date-parts="year" form="text" variable="issued" suffix="."/>
+        </group>
+      </else-if>
+      <else>
+        <date variable="issued" suffix=".">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor" suffix=", ">
+          <label form="short" suffix=" "/>
+          <name and="symbol" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter="," suffix=")">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush" entry-spacing="0" line-spacing="2">
+    <layout>
+      <text variable="citation-number" suffix=")"/>
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="title" suffix=","/>
+        <text variable="container-title" font-style="italic" suffix=","/>
+        <text macro="editor"/>
+        <text variable="volume" font-weight="normal" suffix=","/>
+        <text variable="page" suffix=","/>
+        <text macro="access"/>
+        <text macro="issuance"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/main.typ
+++ b/main.typ
@@ -54,5 +54,5 @@
 // 参考文献
 #[
   #set text(lang: "en")
-  #bibliography(title: "参考文献", style:"ieee", "references.bib")
+  #bibliography(title: "参考文献", style:"lib/jasnaoe-reference.csl", "references.bib")
 ]


### PR DESCRIPTION
This pull request includes changes to support the new citation style for the JASNAOE conference. The most important changes include the addition of the new CSL file and updating the bibliography style in the main document.

Changes to citation style:

* [`lib/jasnaoe-reference.csl`](diffhunk://#diff-f5b3e3bb14f18b600dd7c69baa15ab3ad3691d752997d83caeabaa69db870b57R1-R122): Added a new CSL file defining the citation style for the JASNAOE conference, including macros for title, author, access, issuance, and editor, as well as citation and bibliography layouts.

Updating bibliography style:

* [`main.typ`](diffhunk://#diff-0d17b34bf40cb67e2d6ed40719b4f7647179baf2cd361da9a9a3a4701d496153L57-R57): Updated the bibliography style to use the new `lib/jasnaoe-reference.csl` file instead of the previous IEEE style.