### PR TITLE
remove Typst LSP explanation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,2 @@
 {
-    "typst-lsp.exportPdf": "never"
 }

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ sudo apt-get install msttcorefonts # Times New Roman
 
 複数ファイルに分割して記述するスタイルを採用しているため、VSCodeプラグイン固有の自動コンパイル機能は切っておいた方が良いと思います。
 
-[Typst LSP](https://marketplace.visualstudio.com/items?itemName=nvarner.typst-lsp)であれば、このワークスペースにおいては自動コンパイル機能をoffにする設定にしています。他のTypstコンパイル拡張機能をインストールしている場合は、ご自身で自動コンパイル機能をoffにしてください。
-
 PowershellやTerminalか何かで以下のコマンドを実行することで、ファイルの変更時に自動でコンパイルを行ってpdfファイルを生成してくれます。コンパイルが失敗する場合はエラーメッセージが表示されるので、該当の場所を修正しましょう。
 
 ```sh


### PR DESCRIPTION
This pull request includes changes to the `.vscode/settings.json` and `README.md` files, primarily focused on configuration and documentation updates.

Configuration changes:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L2): Removed the setting `"typst-lsp.exportPdf": "never"`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-L98): Removed the section advising users to turn off the auto-compile feature for Typst LSP in this workspace.