### PR TITLE
update prefix and suffix of citation reference

### DIFF
--- a/lib/jasnaoe-reference.csl
+++ b/lib/jasnaoe-reference.csl
@@ -100,13 +100,13 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter="," suffix=")">
+    <layout delimiter="," prefix="[" suffix="]">
       <text variable="citation-number"/>
     </layout>
   </citation>
   <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush" entry-spacing="0" line-spacing="2">
     <layout>
-      <text variable="citation-number" suffix=")"/>
+      <text variable="citation-number" prefix="[" suffix="]"/>
       <group delimiter=" ">
         <text macro="author"/>
         <text macro="title" suffix=","/>


### PR DESCRIPTION
This pull request includes changes to the citation and bibliography layout in the `lib/jasnaoe-reference.csl` file. The most important change is the modification of the layout delimiters for citation numbers.

Changes to citation and bibliography layout:

* [`lib/jasnaoe-reference.csl`](diffhunk://#diff-f5b3e3bb14f18b600dd7c69baa15ab3ad3691d752997d83caeabaa69db870b57L103-R109): Changed the `layout` delimiter for citation numbers from parentheses to square brackets in both the citation and bibliography sections.