### PR TITLE
Reference order with outline

### DIFF
--- a/contents/how_to_use.typ
+++ b/contents/how_to_use.typ
@@ -15,7 +15,7 @@ Typstでは、PNG・JPEG・GIF・SVG フォーマットの画像をサポート�
 #figure(
   image("img/example.svg", width: 90%),
   placement: none, // top, bottom, auto, none
-  caption: "Example of a figure.",
+  caption: [Example of a figure.],
 ) <fig:fig_example>
 
 === このテンプレートにおける図の記述方法 <how_to_describe_figure_in_this_format>

--- a/lib/grad_thesis_lib.typ
+++ b/lib/grad_thesis_lib.typ
@@ -13,6 +13,10 @@
 
 // Definition of chapter outline
 #let toc() = {
+  show outline.entry: it => {
+    show cite: _ => {} // ← 目次では cite を無視
+    it
+  }
   show outline.entry.where(level: 1): set block(spacing: spaceS_size)
   v(spaceM_size)
   text(size: textM, font: gothic, weight: "bold")[目次]
@@ -23,6 +27,10 @@
 
 // Definition of figure outline
 #let toc_img() = {
+  show outline.entry: it => {
+    show cite: _ => {} // ← 目次では cite を無視
+    it
+  }
   show outline.entry.where(level: 2): set block(spacing: spaceS_size)
   v(spaceM_size)
   text(size: textM, font: gothic, weight: "bold")[図目次] // TODO gothicにする
@@ -33,6 +41,10 @@
 
 // Definition of table outline
 #let toc_table() = {
+  show outline.entry: it => {
+    show cite: _ => {} // ← 目次では cite を無視
+    it
+  }
   show outline.entry.where(level: 2): set block(spacing: spaceS_size)
   v(spaceM_size)
   text(size: textM, font: gothic, weight: "bold")[表目次] // TODO gothicにする

--- a/main.typ
+++ b/main.typ
@@ -52,5 +52,5 @@
 // 参考文献
 #[
   #set text(lang: "en")
-  #bibliography(title: "参考文献", style:"lib/jasnaoe-reference.csl", "references.bib")
+  #bibliography(title: "参考文献", style:"lib/grad_thesis_reference.csl", "references.bib")
 ]


### PR DESCRIPTION
This pull request introduces improvements to the handling of outlines (tables of contents) and figure captions in the Typst template, as well as updates the bibliography style. The main changes focus on ensuring citations are ignored in outlines and updating the bibliography formatting to use a new style.

**Outline handling improvements:**

* Updated `toc`, `toc_img`, and `toc_table` macros in `lib/grad_thesis_lib.typ` to ignore citations when generating outlines, ensuring cleaner tables of contents and lists of figures/tables. [[1]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eR16-R19) [[2]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eR30-R33) [[3]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eR44-R47)

**Figure formatting:**

* Changed the `caption` parameter in a figure example in `contents/how_to_use.typ` to use a list format, improving consistency with Typst's expected input.

**Bibliography formatting:**

* Switched the bibliography style in `main.typ` from `jasnaoe-reference.csl` to `grad_thesis_reference.csl`, likely to better match thesis formatting requirements.