### PR TITLE
GitHub Action for creating PDF

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}main.pdf
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Install fonts
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y fonts-ipafont-mincho fonts-ipafont-gothic -qq
+          sudo apt install tex-gyre -qq
+      - uses: typst-community/setup-typst@v4
+      - name: Compile
+        run: |
+          mkdir ./out
+          typst compile ./main.typ ./out/main.pdf
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq -y fonts-ipafont-mincho fonts-ipafont-gothic
-          sudo apt install tex-gyre -qq
+          sudo apt install -qq tex-gyre
       - uses: typst-community/setup-typst@v4
       - name: Compile
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install fonts
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y fonts-ipafont-mincho fonts-ipafont-gothic -qq
+          sudo apt-get install -qq -y fonts-ipafont-mincho fonts-ipafont-gothic
           sudo apt install tex-gyre -qq
       - uses: typst-community/setup-typst@v4
       - name: Compile

--- a/README.md
+++ b/README.md
@@ -28,19 +28,25 @@ Mac OSの場合は、Terminalか何かで、[Homebrew](https://formulae.brew.sh/
 brew install typst
 ```
 
-### フォントのインストール
+### フォントのインストールール (Mac, Linuxのみ)
 
-現在、フォントについては以下の設定になっています。
-各自のPCにインストールされているフォントと照らし合わせて、前の方から優先的に使われるようです。
+現在，フォントについては以下の設定になっています．
+各自のPCにインストールされているフォントと照らし合わせて，前の方から優先的に使われます．
 
 ```ts
-#let mincho = ("Times New Roman", "IPAMincho")
-#let gothic = ("Times New Roman", "IPAGothic")
+#let mincho = ("TeX Gyre Termes", "IPAMincho")
+#let gothic = ("TeX Gyre Termes", "IPAGothic")
+// #let mincho = ("Times New Roman", "IPAMincho")
+// #let gothic = ("Times New Roman", "IPAGothic")
 // #let mincho = ("Times New Roman", "MS Mincho", "IPAMincho")
 // #let gothic = ("Times New Roman", "MS Gothic", "IPAGothic")
 ```
 
-Typstで認識されているフォントを確認するには、以下のコマンドを実行すると良いです。
+基本的には，英語の場合に優先的に選択されるTeX Gyre Termes，日本語の場合はIPAフォントが使われるように設定しています．
+[指定フォーマット](https://www.jasnaoe.or.jp/lecture/2024aut/thesis.html?id=yoryo)は英語はTimes New Romanフォント、日本語はMSフォントを使っています．
+必要に応じて、コメントアウトしているMSフォントを指定すると良いです。
+
+Typstで認識されているフォントを確認するには，以下のコマンドを実行すると良いです．
 
 ```bash
 typst fonts
@@ -48,11 +54,14 @@ typst fonts
 
 #### Windows
 
-IPAフォントのインストールは[ここ](https://www.kisnet.or.jp/~kanou/index.php?windows/windows%E5%85%B1%E9%80%9A/IPAFont%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB)あたりを参考にしてください。
+Tex Gyre Termsフォントのダウンロードは[ここ](https://www.1001fonts.com/tex-gyre-termes-font.html)からできそうです．
 
-フォントの設定を以下のように変えて、Windowsに搭載されているフォントを使うのも良いかもしれません。
+IPAフォントのダウンロードと新しいフォントのインストールは[ここ](https://www.kisnet.or.jp/~kanou/index.php?windows/windows%E5%85%B1%E9%80%9A/IPAFont%E3%81%AE%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB)あたりを参考にしてください．
+フォントの設定を以下のように変えて、Windowsに搭載されているフォントを使うのも良いかもしれません．
 
 ```ts
+// #let mincho = ("TeX Gyre Termes", "IPAMincho")
+// #let gothic = ("TeX Gyre Termes", "IPAGothic")
 // #let mincho = ("Times New Roman", "IPAMincho")
 // #let gothic = ("Times New Roman", "IPAGothic")
 #let mincho = ("Times New Roman", "MS Mincho", "IPAMincho")
@@ -61,41 +70,45 @@ IPAフォントのインストールは[ここ](https://www.kisnet.or.jp/~kanou/
 
 #### Mac OS
 
-おそらく、MacではTimes New Romanは入っているけども、ゴシックや明朝はフォントをインストールする必要があります。
+おそらく，MacではTimes New Romanは入っているけども，ゴシックや明朝はフォントをインストールする必要があります．
 
-IPAフォントであれば、[Homebrew](https://formulae.brew.sh/)を利用して簡単にインストールできます。
+IPAフォントであれば，[Homebrew](https://formulae.brew.sh/)を利用して簡単にインストールできます．
 
 ```bash
+brew install --cask font-tex-gyre-termes
 brew install --cask font-ipafont
 ```
 
-MSフォントは、Microsoft OfficeがインストールされているPCであれば[この記事](https://note.com/tomorrow311/n/ne835a8c525a9)の方法で取り込めそうですが、ご自身の責任でお願いします。
+Times New RomanフォントやMSフォントを使用する場合は，Microsoft OfficeがインストールされているPCであれば[この記事](https://note.com/tomorrow311/n/ne835a8c525a9)の方法で取り込めそうですが，ご自身の責任でお願いします．
 
 #### Linux
 
-以下の方法でインストールできそうです。
+IPAフォントは以下の方法でインストールできそうです．
 
 ```bash
 # Debian系(Ubuntu)
+sudo apt install tex-gyre
 sudo apt-get install fonts-ipafont
-sudo apt-get install msttcorefonts # Times New Roman
 ```
 
-## How to use
+## 使用方法
 
-### 1. レポジトリの用意
+### 1. ファイルを準備する
 
-- GitHubアカウントを持っている方は、`use this template` で、自分用のレポジトリを生成してください。
-  - Privateレポジトリにし、必要に応じて指導教員を共同編集者に招待することをおすすめします。
+- GitHubアカウントを持っている方は，`use this template` で．自分用のレポジトリを生成してください
 
-### 2. 執筆環境設定(VSCode)
+- GitHubアカウントを持っていない方は，このGitHubページの `<>Code▼` から `Download ZIP` し，ZIPファイルを解凍して使用してください．
 
-ローカルPCにTypstとVisual Studio Code(VSCode)がインストールされている前提で説明を続けます。
+### 2. 編集&コンパイルでpdfを作成する
 
-複数ファイルに分割して記述するスタイルを採用しているため、VSCodeプラグイン固有の自動コンパイル機能は切っておいた方が良いと思います。
+編集するファイルはmain.typです．
 
-PowershellやTerminalか何かで以下のコマンドを実行することで、ファイルの変更時に自動でコンパイルを行ってpdfファイルを生成してくれます。コンパイルが失敗する場合はエラーメッセージが表示されるので、該当の場所を修正しましょう。
+#### コンソールでコンパイルをする場合 (推奨)
+
+以下のコマンドを実行することでファイルの変更時に自動でコンパイルを行ってpdfファイルを生成してくれます。コンパイルが失敗する場合はエラーメッセージが表示されるので、該当の場所を修正しましょう。
 
 ```sh
 typst watch main.typ main.pdf
 ```
+
+詳しくは、[公式サイト](https://github.com/typst/typst?tab=readme-ov-file#usage)を参照ください．

--- a/lib/grad_thesis_lib.typ
+++ b/lib/grad_thesis_lib.typ
@@ -1,5 +1,7 @@
-#let mincho = ("Times New Roman", "IPAMincho")
-#let gothic = ("Times New Roman", "IPAGothic")
+#let mincho = ("TeX Gyre Termes", "IPAMincho")
+#let gothic = ("TeX Gyre Termes", "IPAGothic")
+// #let mincho = ("Times New Roman", "IPAMincho")
+// #let gothic = ("Times New Roman", "IPAGothic")
 // #let mincho = ("Times New Roman", "MS Mincho", "IPAMincho")
 // #let gothic = ("Times New Roman", "MS Gothic", "IPAGothic")
 
@@ -33,7 +35,7 @@
   }
   show outline.entry.where(level: 2): set block(spacing: spaceS_size)
   v(spaceM_size)
-  text(size: textM, font: gothic, weight: "bold")[図目次] // TODO gothicにする
+  text(size: textM, font: gothic, weight: "bold")[図目次]
   v(spaceS_size)
   outline(indent: spaceS_size, title: none, target: figure.where(kind: image))
   pagebreak(weak: true)
@@ -47,7 +49,7 @@
   }
   show outline.entry.where(level: 2): set block(spacing: spaceS_size)
   v(spaceM_size)
-  text(size: textM, font: gothic, weight: "bold")[表目次] // TODO gothicにする
+  text(size: textM, font: gothic, weight: "bold")[表目次]
   v(spaceS_size)
   outline(indent: spaceS_size, title: none, target: figure.where(kind: table))
   pagebreak(weak: true)


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for automatic PDF deployment, updates font selection and installation instructions, and improves Japanese language and formatting consistency across documentation and source files. The main themes are automation of PDF builds, improved font configuration, and clearer user instructions.

**Automation and Deployment:**
- Added a new GitHub Actions workflow (`.github/workflows/gh-pages.yml`) to automatically build the Typst project and deploy the resulting PDF to GitHub Pages on every push to the `main` branch or via manual trigger. The workflow installs necessary fonts and sets up the build environment for consistent output.

**Font Configuration and Usage:**
- Changed the default font order in both `lib/grad_thesis_lib.typ` and `README.md` to prefer `"TeX Gyre Termes"` for English and `"IPAMincho"`/`"IPAGothic"` for Japanese, with commented alternatives for Times New Roman and MS fonts. This ensures better cross-platform compatibility and aligns with the recommended format. [[1]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eL1-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R64)
- Updated font installation instructions in the `README.md` for Mac and Linux, including commands to install TeX Gyre and IPA fonts, and clarified how to check available fonts with `typst fonts`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R64) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R114)

**Documentation and Usability:**
- Revised and expanded usage instructions in the `README.md`, including how to prepare the repository, edit files, and compile PDFs—emphasizing the use of `typst watch` for automatic compilation and referencing the official documentation.

**Minor Improvements:**
- Removed outdated comments (e.g., `// TODO gothicにする`) in section headings in `lib/grad_thesis_lib.typ` for clarity and consistency. [[1]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eL36-R38) [[2]](diffhunk://#diff-a6fd65e0eebdae70f23ae0289a722b199612a9ebf7d5fa15eeda6b718f46d91eL50-R52)
- Improved Japanese language consistency and formatting throughout the `README.md` and source files for a more professional and user-friendly experience. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R64) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R114)