### PR TITLE
contents: read

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}main.pdf
     permissions:
+      contents: read
       pages: write
       id-token: write
     steps:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow permissions to ensure the correct access level for publishing pages.

* Workflow permissions: Added `contents: read` permission to the `github-pages` job in `.github/workflows/gh-pages.yml` to explicitly allow read access to repository contents.