### PR TITLE
Multiple line caption

### DIFF
--- a/contents/how_to_use.typ
+++ b/contents/how_to_use.typ
@@ -15,7 +15,7 @@ Typstでは、PNG・JPEG・GIF・SVG フォーマットの画像をサポート�
 #figure(
   image("img/example.svg", width: 90%),
   placement: none, // top, bottom, auto, none
-  caption: [Example of a figure.],
+  caption: [Example of a figure of each simple and easy and great and beautiful aaaaa mathematical equation.],
 ) <fig:fig_example>
 
 === このテンプレートにおける図の記述方法 <how_to_describe_figure_in_this_format>
@@ -28,7 +28,7 @@ Typstの文法とこのテンプレートに沿って、図を記述する方法
 #figure(
   placement: none, // top, bottom, auto, none
   image("img/example.svg", width: 90%),
-  caption: [Example of a figure.],
+  caption: [Example of a figure of each simple and easy mathematical equation.],
 ) <fig:fig_example> // 図の参照用のラベル
 ```
 

--- a/contents/how_to_use.typ
+++ b/contents/how_to_use.typ
@@ -15,7 +15,7 @@ Typstでは、PNG・JPEG・GIF・SVG フォーマットの画像をサポート�
 #figure(
   image("img/example.svg", width: 90%),
   placement: none, // top, bottom, auto, none
-  caption: [Example of a figure of each simple and easy and great and beautiful aaaaa mathematical equation.],
+  caption: [Example of a figure of each simple and easy and great and beautiful mathematical equation.],
 ) <fig:fig_example>
 
 === このテンプレートにおける図の記述方法 <how_to_describe_figure_in_this_format>

--- a/lib/grad_thesis_lib.typ
+++ b/lib/grad_thesis_lib.typ
@@ -13,6 +13,8 @@
 #let spaceS_size = 1.5em
 #let spaceM_size = 3.0em
 
+#let max_width = 170.0mm // 1 column(210.0mm - left margin(17.0mm) - right margin(17.0mm) - margin(6.0mm))
+
 // Definition of chapter outline
 #let toc() = {
   show outline.entry: it => {
@@ -189,8 +191,25 @@
   show figure.where(kind: image): set figure.caption(position: bottom, separator: [ ])
   show math.equation: set math.equation(supplement: [Eq.])
 
-  show figure.caption: it => {
-    align(box(align(it, left)), center)
+  show figure.caption: it => context {
+    let label = it.supplement + " " + str(it.counter.display(it.numbering))
+    
+    let full_text = label + it.body
+    if measure(full_text).width <= max_width [
+      #align(box(align(it, left)), center)
+    ] else [
+    // Output in 2-column layout
+      #grid(
+        columns: (auto, 1fr),
+        gutter: 0.5em,
+        [
+          #label
+        ],
+        [
+          #box(align(it.body, left))
+        ]
+      )
+    ]
   }
 
   // Display block code in a larger block with more padding.

--- a/lib/grad_thesis_lib.typ
+++ b/lib/grad_thesis_lib.typ
@@ -13,7 +13,7 @@
 #let spaceS_size = 1.5em
 #let spaceM_size = 3.0em
 
-#let max_width = 170.0mm // 1 column(210.0mm - left margin(17.0mm) - right margin(17.0mm) - margin(6.0mm))
+#let max_width = 160.0mm // 1 column(210.0mm - left margin(17.0mm) - right margin(17.0mm) - margin(16.0mm))
 
 // Definition of chapter outline
 #let toc() = {


### PR DESCRIPTION
This pull request introduces improvements to figure captions and layout handling in Typst documents, as well as a new layout constant. The main focus is on enhancing how figure captions are displayed, especially when they are long, by automatically adjusting the layout for better readability.

**Figure caption improvements and layout handling:**

* Updated the figure captions in `contents/how_to_use.typ` to use more descriptive text for the examples. [[1]](diffhunk://#diff-1ea6b0ec1176c1f4debf189ca10d32d5d7994fac3ade9e0e6a45c518cc491bd6L18-R18) [[2]](diffhunk://#diff-1ea6b0ec1176c1f4debf189ca10d32d5d7994fac3ade9e0e6a45c518cc491bd6L31-R31)
* Enhanced the `figure.caption` display logic in `lib/grad_thesis_lib.typ` to automatically switch to a two-column layout if the caption text exceeds a specified maximum width, improving readability for long captions.

**New layout constant:**

* Introduced a `max_width` constant in `lib/grad_thesis_lib.typ` to define the maximum width for single-column captions, which is used to trigger the two-column layout when needed.